### PR TITLE
Typecasting weirdness

### DIFF
--- a/fileio.c
+++ b/fileio.c
@@ -299,13 +299,13 @@ int filereadint32(fileinfo *file, unsigned long *val32, char const *msg)
 
     errno = 0;
     if ((byte = fgetc(file->fp)) != EOF) {
-	*val32 = (unsigned char)byte;
+	*val32 = (unsigned long)byte;
 	if ((byte = fgetc(file->fp)) != EOF) {
-	    *val32 |= (unsigned char)byte << 8;
+	    *val32 |= (unsigned long)byte << 8;
 	    if ((byte = fgetc(file->fp)) != EOF) {
-		*val32 |= (unsigned char)byte << 16;
+		*val32 |= (unsigned long)byte << 16;
 		if ((byte = fgetc(file->fp)) != EOF) {
-		    *val32 |= (unsigned char)byte << 24;
+		    *val32 |= (unsigned long)byte << 24;
 		    return TRUE;
 		}
 	    }


### PR DESCRIPTION
Despite explicitly typecasting the signed int byte to an unsigned char, it looks like the value was being implicitly cast back to a signed value before the bit shift occurred. The program behaved as expected until the 24-bit shift, at which point the high bit being a 1 made the situation somewhat clearer.

```
(gdb) n
308             *val32 |= (unsigned char)byte << 24;
(gdb) p/x *val32
$27 = 0x9b3335
(gdb) n
315 }
(gdb) p/x *val32
$28 = 0xffffffff999b3335
```

After I cast the byte to an unsigned long instead, the problem went away.
