### PR TITLE
Switched to using the basename in default.o.do

### DIFF
--- a/default.o.do
+++ b/default.o.do
@@ -1,4 +1,4 @@
-redo-ifchange $1.c
-gcc -O2 -flto -g -c -o "$3" "$1.c" -Wall
-gcc -MM "$1.c" | read headers
+redo-ifchange $2.c
+gcc -O2 -flto -g -c -o "$3" "$2.c" -Wall
+gcc -MM "$2.c" | read headers
 redo-ifchange ${headers#*:}


### PR DESCRIPTION
Building with [redo-0.11](https://github.com/apenwarr/redo/tree/redo-0.11) gives

```
redo  all
redo    tws2json
redo      tws2json.o
redo        no rule to make 'tws2json.o.c'
redo      tws2json.o: exit code 1
redo    tws2json: exit code 1
redo  all: exit code 1
```

Using the [basename](https://github.com/apenwarr/redo/blob/redo-0.11/Documentation/redo.md#discussion) seems to solve the problem.
